### PR TITLE
Update crate version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ intended to be a replacement for libm. For that, look to something like `m`.
 Add this to your `Cargo.toml`
 
 ```toml
-mish = "0.2.0"
+mish = "0.2.1"
 ```
 
 add this to your crate root


### PR DESCRIPTION
According to `crates.io`, `mish` is in version `0.2.1`. According to the README, it is version `0.2.0`. I figured I would let you know to avoid future confusion.