### PR TITLE
Improve accuracy of various functions in edge cases

### DIFF
--- a/src/funcs/m.rs
+++ b/src/funcs/m.rs
@@ -55,7 +55,13 @@ pub fn powf<T: Flt>(f: T, p: T) -> T {
 }
 
 pub fn sqrt<T: Flt>(f: T) -> T {
-    sqrt_(f, 25)
+    if f < T::ZERO {
+        T::NAN
+    }else if f < T::ONE {
+        recip(sqrt_(recip(f), 25))
+    } else {
+        sqrt_(f, 25)
+    }
 }
 
 pub fn sqrt_<T: Flt>(f: T, n: u16) -> T {

--- a/src/funcs/m.rs
+++ b/src/funcs/m.rs
@@ -39,7 +39,13 @@ pub fn exp<T: Flt>(p: T) -> T {
 }
 
 pub fn ln<T: Flt>(p: T) -> T {
-    ln_(p, 300)
+    if p <= T::ZERO {
+        T::NAN
+    } else if p < T::ONE {
+        -ln_(recip(p), 300)
+    } else {
+        ln_(p, 300)
+    }
 }
 
 pub fn ln_<T: Flt>(p: T, n: i16) -> T {

--- a/src/funcs/m.rs
+++ b/src/funcs/m.rs
@@ -21,7 +21,11 @@ pub fn powi<T: Flt>(f: T, p: i16) -> T {
 }
 
 pub fn expm1<T: Flt>(p: T) -> T {
-    expm1_(p, 15)
+    if p < T::ZERO {
+        recip(expm1_(-p, 15) + T::ONE) - T::ONE
+    } else {
+        expm1_(p, 15)
+    }
 }
 
 pub fn expm1_<T: Flt>(p: T, n: i16) -> T {

--- a/src/funcs/t/t.rs
+++ b/src/funcs/t/t.rs
@@ -1,12 +1,26 @@
 use super::super::m::powi;
 use Flt;
 
-pub fn sin<T: Flt>(x: T) -> T {
+/// This is very good for -pi/2 < x < pi/2
+/// It gets worse outside this interval
+fn sin_maclaurin<T: Flt>(x: T) -> T {
     x - powi(x, 3) / T::C6 + powi(x, 5) / T::C120 - powi(x, 7) / T::C5040 + powi(x, 9) / T::C362880
 }
 
 pub fn cos<T: Flt>(x: T) -> T {
-    sin(T::PI2 - x)
+    let abs_x = if x < T::ZERO { -x } else { x };
+    // Between 0 and 2*pi
+    let standard_position = abs_x % (T::TWO * T::PI);
+    // Make the argument to sin_maclaurin be between -pi/2 and pi/2
+    if standard_position < T::PI {
+        sin_maclaurin(T::PI2 - standard_position)
+    } else {
+        sin_maclaurin(standard_position - T::PI2 - T::PI)
+    }
+}
+
+pub fn sin<T: Flt>(x: T) -> T {
+    cos(T::PI2 - x)
 }
 
 pub fn tan<T: Flt>(x: T) -> T {


### PR DESCRIPTION
Fixes #2.

Some of the approximations yielded crazy answers for inputs that they weren't designed to deal with, such as `ln` giving 10^40 for inputs near 0.3 (the real answer is about -1.2).

This fixes it simply, by adding if statements and transforming it to numbers in the reasonable domain of the approximations.  For `ln`, for example, it computes the log of numbers less than 1 by doing `-ln(1/x)`.

Not all the functions are modified; just the ones I needed to fix edge cases for to use.

Here's my reasoning behind what I changed:
* I graphed all the things I was using, and modified the ones that looked incorrect to be better
* Using these modifications made the test suite for the palette crate pass when it didn't before
* The `mish` test suite results have not changed